### PR TITLE
always use subdomain rewrite

### DIFF
--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -57,16 +57,24 @@ module.exports = function bins(dsnStr) {
 		},
 		{
 			action: "get",
-			path: "/log/:uuid*",
+			path: ":serviceid/log/:custompath*",
 			route: routes.log(client),
 		},
 		{
 			action: "delete",
-			path: "/delete/:uuid*",
+			path: ":serviceid/delete/:custompath*",
 			route: routes.delete(client),
 		},
-		{ action: "put", path: "/upsert/:uuid*", route: routes.update(client) },
-		{ action: "all", path: "/:uuid*", route: routes.run(client) },
+		{
+			action: "put",
+			path: ":serviceid/upsert/:custompath*",
+			route: routes.update(client),
+		},
+		{
+			action: "all",
+			path: "/:serviceid/:custompath*",
+			route: routes.run(client),
+		},
 	];
 
 	endpoints.forEach((endpoint) => {

--- a/lib/routes/bins/delete.js
+++ b/lib/routes/bins/delete.js
@@ -1,7 +1,7 @@
 const debug = require("debug")("mockbin");
 
 module.exports = (client) => (req, res, next) => {
-	const compoundId = req.params.uuid + req.params[0];
+	const compoundId = req.params.serviceid + req.params.custompath;
 	client.del(`bin:${compoundId}`, (err) => {
 		if (err) {
 			debug(err);

--- a/lib/routes/bins/log.js
+++ b/lib/routes/bins/log.js
@@ -3,7 +3,7 @@ const pkg = require("../../../package.json");
 
 module.exports = (client) => (req, res, next) => {
 	res.view = "bin/log";
-	const compoundId = req.params.uuid + req.params[0];
+	const compoundId = req.params.serviceid + req.params.custompath;
 	client.lrange(`log:${compoundId}`, 0, -1, (err, history) => {
 		if (err) {
 			debug(err);

--- a/lib/routes/bins/run.js
+++ b/lib/routes/bins/run.js
@@ -2,7 +2,7 @@ const debug = require("debug")("mockbin");
 
 module.exports = (client) => (req, res, next) => {
 	// compoundId allows us to provide paths in the id to resolve to a specific bin
-	const compoundId = req.params.uuid + req.params[0];
+	const compoundId = req.params.serviceid + req.params.custompath;
 	client.get(`bin:${compoundId}`, function (err, value) {
 		if (err) {
 			debug(err);

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -4,9 +4,7 @@ const validate = require("har-validator");
 const path = require("node:path");
 
 module.exports = (client) => (req, res, next) => {
-	const id = req.params.uuid;
-	const path = req.params[0];
-	const compoundId = id + path;
+	const compoundId = req.params.serviceid + req.params.custompath;
 
 	let mock = req.jsonBody;
 


### PR DESCRIPTION
spike:
would require all paths to split the redis id into server id and custom path and for the verb to be between them