### PR TITLE
Fix npm audit warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,3 +12,4 @@ jobs:
     - uses: biomejs/setup-biome@v2
     - run: biome ci .
     - run: npm test
+    - run: npm audit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,4 +12,4 @@ jobs:
     - uses: biomejs/setup-biome@v2
     - run: biome ci .
     - run: npm test
-    - run: npm audit
+    - run: npm audit --audit-level=moderate

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
-	"editor.defaultFormatter": "biomejs.biome",
-	"editor.formatOnSave": true
+	"editor.formatOnSave": true,
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
 	"editor.formatOnSave": true,
 	"[javascript]": {
 		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[json]": {
+		"editor.defaultFormatter": "biomejs.biome"
 	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21.6.2-bullseye-slim
+FROM node:22-bullseye-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 ENV NODE_ENV production

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ const express = require("express");
 const mw = require("./middleware");
 const routes = require("./routes");
 
-module.exports = function router(options) {
+module.exports = function (options) {
 	const router = express.Router();
 
 	const defaults = [

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,10 +7,8 @@ module.exports = function router(options) {
 	const router = express.Router();
 
 	const defaults = [
-		mw.forwarded,
 		mw.errorHandler,
 		mw.bodyParser,
-		null,
 		mw.cors,
 		mw.poweredBy,
 		mw.negotiateContent,
@@ -19,14 +17,12 @@ module.exports = function router(options) {
 	const endpoints = [
 		{ action: "get", path: "/", route: routes.hello },
 		{ action: "all", path: "/ip", route: routes.ips.one },
-		{ action: "all", path: "/ips", route: routes.ips.all },
 		{ action: "all", path: "/agent", route: routes.headers.agent },
 		{ action: "all", path: "/status/:code/:reason?", route: routes.status },
 		{ action: "all", path: "/headers", route: routes.headers.all },
 		{ action: "all", path: "/header/:name", route: routes.headers.one },
 		{ action: "all", path: "/header/:name/:value", route: routes.headers.set },
 		{ action: "all", path: "/cookies", route: routes.cookies.all },
-		{ action: "all", path: "/forwarded", route: routes.forwarded },
 		{ action: "all", path: "/cookie/:name", route: routes.cookies.one },
 		{ action: "all", path: "/cookie/:name/:value", route: routes.cookies.set },
 		{

--- a/lib/middleware/body-parser.js
+++ b/lib/middleware/body-parser.js
@@ -1,4 +1,4 @@
-const Dicer = require("dicer");
+const Dicer = require("@idio/dicer");
 const querystring = require("node:querystring");
 const contentTypeParser = require("content-type");
 const util = require("../utils");

--- a/lib/middleware/forwarded.js
+++ b/lib/middleware/forwarded.js
@@ -1,3 +1,0 @@
-const forwarded = require("forwarded-http/lib/middleware");
-
-module.exports = forwarded({ allowPrivate: true });

--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -30,7 +30,6 @@ module.exports = function bins(dsnStr) {
 	const router = express.Router();
 
 	const defaults = [
-		mw.forwarded,
 		mw.errorHandler,
 		mw.bodyParser,
 		null,

--- a/lib/routes/delay.js
+++ b/lib/routes/delay.js
@@ -1,4 +1,4 @@
-module.exports = function delay(req, res, next) {
+module.exports = function (req, res, next) {
 	let delay = req.params.ms ? Number.parseInt(req.params.ms, 10) : 200;
 
 	if (delay > 60000) {

--- a/lib/routes/forwarded.js
+++ b/lib/routes/forwarded.js
@@ -1,5 +1,0 @@
-module.exports = function forwarded(req, res, next) {
-	res.body = req.forwarded;
-
-	next();
-};

--- a/lib/routes/ips.js
+++ b/lib/routes/ips.js
@@ -4,10 +4,4 @@ module.exports = {
 
 		next();
 	},
-
-	all: function allIPs(req, res, next) {
-		res.body = req.forwarded.for;
-
-		next();
-	},
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,7 +50,7 @@ const utils = {
 					clientIPAddress: req.ip,
 					request: {
 						method: req.method,
-						url: `${req.forwarded.proto}://${req.hostname}${req.originalUrl}`,
+						url: `${req.protocol}://${req.hostname}${req.originalUrl}`,
 						httpVersion: "HTTP/1.1",
 						// TODO, add cookie details
 						cookies: utils.objectToArray(req.cookies),
@@ -76,7 +76,7 @@ const utils = {
 		startedDateTime: new Date().toISOString(),
 		clientIPAddress: req.ip,
 		method: req.method,
-		url: `${req.forwarded.proto}://${req.hostname}${req.originalUrl}`,
+		url: `${req.protocol}://${req.hostname}${req.originalUrl}`,
 		httpVersion: "HTTP/1.1",
 		// TODO, add cookie details
 		cookies: req.cookies,

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"should": "^13.2.3"
 			},
 			"engines": {
-				"node": ">=21"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@biomejs/biome": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
 				"dicer": "^0.3.0",
 				"dotenv": "^16.4.0",
 				"express": "^4.17.1",
-				"forwarded-http": "^0.3.0",
 				"har-validator": "^5.1.3",
 				"jstransformer-marked": "^1.4.0",
 				"method-override": "^3.0.0",
@@ -365,43 +364,9 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
-		"node_modules/arr-diff": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"arr-flatten": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/arr-flatten": {
-			"version": "1.1.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/arr-map": {
-			"version": "2.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"make-iterator": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/array-flatten": {
 			"version": "1.1.1",
 			"license": "MIT"
-		},
-		"node_modules/array-unique": {
-			"version": "0.2.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/asap": {
 			"version": "2.0.6",
@@ -511,18 +476,6 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/braces": {
-			"version": "1.8.5",
-			"license": "MIT",
-			"dependencies": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/browser-stdout": {
@@ -829,21 +782,6 @@
 			"version": "2.1.2",
 			"license": "MIT"
 		},
-		"node_modules/deep-equal": {
-			"version": "1.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.1",
-				"is-regex": "^1.0.4",
-				"object-is": "^1.0.1",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/define-data-property": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
@@ -852,16 +790,6 @@
 				"get-intrinsic": "^1.2.1",
 				"gopd": "^1.0.1",
 				"has-property-descriptors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/define-properties": {
-			"version": "1.1.3",
-			"license": "MIT",
-			"dependencies": {
-				"object-keys": "^1.0.12"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -939,44 +867,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/es-abstract": {
-			"version": "1.17.4",
-			"license": "MIT",
-			"dependencies": {
-				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
-				"object-inspect": "^1.7.0",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/es-to-primitive": {
-			"version": "1.2.1",
-			"license": "MIT",
-			"dependencies": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
 			"dev": true,
@@ -996,26 +886,6 @@
 			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/expand-brackets": {
-			"version": "0.1.5",
-			"license": "MIT",
-			"dependencies": {
-				"is-posix-bracket": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/expand-range": {
-			"version": "1.8.2",
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/express": {
@@ -1112,16 +982,6 @@
 				}
 			]
 		},
-		"node_modules/extglob": {
-			"version": "0.3.2",
-			"license": "MIT",
-			"dependencies": {
-				"is-extglob": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.1",
 			"license": "MIT"
@@ -1129,27 +989,6 @@
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"license": "MIT"
-		},
-		"node_modules/filename-regex": {
-			"version": "2.0.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/fill-range": {
-			"version": "2.2.4",
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/finalhandler": {
 			"version": "1.2.0",
@@ -1196,54 +1035,12 @@
 				"flat": "cli.js"
 			}
 		},
-		"node_modules/for-in": {
-			"version": "1.0.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/for-own": {
-			"version": "0.1.5",
-			"license": "MIT",
-			"dependencies": {
-				"for-in": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/forwarded": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
 			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/forwarded-http": {
-			"version": "0.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"commander": "^2.8.1",
-				"debug": "^2.2.0",
-				"ip": "^0.3.2",
-				"ip-filter": "^1.0.0",
-				"ip-port-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/forwarded-http/node_modules/commander": {
-			"version": "2.20.3",
-			"license": "MIT"
-		},
-		"node_modules/forwarded-http/node_modules/debug": {
-			"version": "2.6.9",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
 			}
 		},
 		"node_modules/fresh": {
@@ -1327,24 +1124,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/glob-base": {
-			"version": "0.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/glob-parent": {
-			"version": "2.0.0",
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^2.0.0"
 			}
 		},
 		"node_modules/gopd": {
@@ -1500,49 +1279,12 @@
 			"version": "2.0.4",
 			"license": "ISC"
 		},
-		"node_modules/ip": {
-			"version": "0.3.3",
-			"license": "MIT"
-		},
-		"node_modules/ip-filter": {
-			"version": "1.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"ip-regex": "^1.0.3",
-				"is-match": "^0.4.0",
-				"to-file-path": "^1.0.0"
-			}
-		},
-		"node_modules/ip-port-regex": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"ip-regex": "^1.0.3"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/ip-regex": {
-			"version": "1.0.3",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/is-arguments": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/is-binary-path": {
@@ -1555,20 +1297,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-buffer": {
-			"version": "1.1.6",
-			"license": "MIT"
-		},
-		"node_modules/is-callable": {
-			"version": "1.1.5",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-core-module": {
@@ -1585,33 +1313,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-date-object": {
-			"version": "1.0.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-dotfile": {
-			"version": "1.0.3",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-equal-shallow": {
-			"version": "0.1.3",
-			"license": "MIT",
-			"dependencies": {
-				"is-primitive": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-expression": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
@@ -1619,67 +1320,6 @@
 			"dependencies": {
 				"acorn": "^7.1.1",
 				"object-assign": "^4.1.1"
-			}
-		},
-		"node_modules/is-extendable": {
-			"version": "0.1.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-extglob": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-glob": {
-			"version": "2.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"is-extglob": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-match": {
-			"version": "0.4.1",
-			"license": "MIT",
-			"dependencies": {
-				"deep-equal": "^1.0.1",
-				"is-extendable": "^0.1.1",
-				"is-glob": "^2.0.1",
-				"micromatch": "^2.3.7"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-number": {
-			"version": "2.1.0",
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-posix-bracket": {
-			"version": "0.1.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-primitive": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-promise": {
@@ -1700,19 +1340,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-symbol": {
-			"version": "1.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"has-symbols": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1723,20 +1350,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"license": "MIT"
-		},
-		"node_modules/isobject": {
-			"version": "2.1.0",
-			"license": "MIT",
-			"dependencies": {
-				"isarray": "1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/js-stringify": {
@@ -1775,23 +1388,6 @@
 			},
 			"engines": {
 				"node": ">= 12"
-			}
-		},
-		"node_modules/kind-of": {
-			"version": "3.2.2",
-			"license": "MIT",
-			"dependencies": {
-				"is-buffer": "^1.1.5"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/lazy-cache": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/log-symbols": {
@@ -1878,27 +1474,6 @@
 				"tslib": "^1.10.0"
 			}
 		},
-		"node_modules/make-iterator": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^6.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/make-iterator/node_modules/kind-of": {
-			"version": "6.0.3",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/math-random": {
-			"version": "1.0.4",
-			"license": "MIT"
-		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -1936,28 +1511,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/micromatch": {
-			"version": "2.3.11",
-			"license": "MIT",
-			"dependencies": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/mime": {
@@ -2324,16 +1877,6 @@
 				"tslib": "^1.10.0"
 			}
 		},
-		"node_modules/normalize-path": {
-			"version": "2.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"remove-trailing-separator": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2348,47 +1891,6 @@
 			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-is": {
-			"version": "1.0.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.assign": {
-			"version": "4.1.0",
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.omit": {
-			"version": "2.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/on-finished": {
@@ -2421,19 +1923,6 @@
 			"dependencies": {
 				"dot-case": "^3.0.3",
 				"tslib": "^1.10.0"
-			}
-		},
-		"node_modules/parse-glob": {
-			"version": "3.0.4",
-			"license": "MIT",
-			"dependencies": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/parseurl": {
@@ -2485,13 +1974,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/preserve": {
-			"version": "0.2.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/promise": {
@@ -2647,32 +2129,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/randomatic": {
-			"version": "3.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			}
-		},
-		"node_modules/randomatic/node_modules/is-number": {
-			"version": "4.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/randomatic/node_modules/kind-of": {
-			"version": "6.0.3",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2735,48 +2191,6 @@
 				"@redis/json": "1.0.6",
 				"@redis/search": "1.1.6",
 				"@redis/time-series": "1.0.5"
-			}
-		},
-		"node_modules/regex-cache": {
-			"version": "0.4.4",
-			"license": "MIT",
-			"dependencies": {
-				"is-equal-shallow": "^0.1.3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/regexp.prototype.flags": {
-			"version": "1.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/remove-trailing-separator": {
-			"version": "1.1.0",
-			"license": "ISC"
-		},
-		"node_modules/repeat-element": {
-			"version": "1.1.3",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/repeat-string": {
-			"version": "1.6.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10"
 			}
 		},
 		"node_modules/require-directory": {
@@ -3010,34 +2424,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/string.prototype.trimleft": {
-			"version": "2.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trimright": {
-			"version": "2.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3067,16 +2453,6 @@
 			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/to-file-path": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"arr-map": "^2.0.0",
-				"is-arguments": "^1.0.2",
-				"isarray": "^1.0.0",
-				"lazy-cache": "^1.0.3"
 			}
 		},
 		"node_modules/to-regex-range": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"mockbin": "bin/mockbin"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "1.6.4",
+				"@biomejs/biome": "1.8.3",
 				"mocha": "^10.2.0",
 				"should": "^13.2.3"
 			},
@@ -81,9 +81,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.6.4.tgz",
-			"integrity": "sha512-3groVd2oWsLC0ZU+XXgHSNbq31lUcOCBkCcA7sAQGBopHcmL+jmmdoWlY3S61zIh+f2mqQTQte1g6PZKb3JJjA==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.8.3.tgz",
+			"integrity": "sha512-/uUV3MV+vyAczO+vKrPdOW0Iaet7UnJMU4bNMinggGJTAnBPjCoLEYcyYtYHNnUNYlv4xZMH6hVIQCAozq8d5w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -97,20 +97,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "1.6.4",
-				"@biomejs/cli-darwin-x64": "1.6.4",
-				"@biomejs/cli-linux-arm64": "1.6.4",
-				"@biomejs/cli-linux-arm64-musl": "1.6.4",
-				"@biomejs/cli-linux-x64": "1.6.4",
-				"@biomejs/cli-linux-x64-musl": "1.6.4",
-				"@biomejs/cli-win32-arm64": "1.6.4",
-				"@biomejs/cli-win32-x64": "1.6.4"
+				"@biomejs/cli-darwin-arm64": "1.8.3",
+				"@biomejs/cli-darwin-x64": "1.8.3",
+				"@biomejs/cli-linux-arm64": "1.8.3",
+				"@biomejs/cli-linux-arm64-musl": "1.8.3",
+				"@biomejs/cli-linux-x64": "1.8.3",
+				"@biomejs/cli-linux-x64-musl": "1.8.3",
+				"@biomejs/cli-win32-arm64": "1.8.3",
+				"@biomejs/cli-win32-x64": "1.8.3"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.6.4.tgz",
-			"integrity": "sha512-2WZef8byI9NRzGajGj5RTrroW9BxtfbP9etigW1QGAtwu/6+cLkdPOWRAs7uFtaxBNiKFYA8j/BxV5zeAo5QOQ==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.8.3.tgz",
+			"integrity": "sha512-9DYOjclFpKrH/m1Oz75SSExR8VKvNSSsLnVIqdnKexj6NwmiMlKk94Wa1kZEdv6MCOHGHgyyoV57Cw8WzL5n3A==",
 			"cpu": [
 				"arm64"
 			],
@@ -124,9 +124,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.6.4.tgz",
-			"integrity": "sha512-uo1zgM7jvzcoDpF6dbGizejDLCqNpUIRkCj/oEK0PB0NUw8re/cn1EnxuOLZqDpn+8G75COLQTOx8UQIBBN/Kg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.8.3.tgz",
+			"integrity": "sha512-UeW44L/AtbmOF7KXLCoM+9PSgPo0IDcyEUfIoOXYeANaNXXf9mLUwV1GeF2OWjyic5zj6CnAJ9uzk2LT3v/wAw==",
 			"cpu": [
 				"x64"
 			],
@@ -140,9 +140,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.6.4.tgz",
-			"integrity": "sha512-wAOieaMNIpLrxGc2/xNvM//CIZg7ueWy3V5A4T7gDZ3OL/Go27EKE59a+vMKsBCYmTt7jFl4yHz0TUkUbodA/w==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.8.3.tgz",
+			"integrity": "sha512-fed2ji8s+I/m8upWpTJGanqiJ0rnlHOK3DdxsyVLZQ8ClY6qLuPc9uehCREBifRJLl/iJyQpHIRufLDeotsPtw==",
 			"cpu": [
 				"arm64"
 			],
@@ -156,9 +156,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.6.4.tgz",
-			"integrity": "sha512-Hp8Jwt6rjj0wCcYAEN6/cfwrrPLLlGOXZ56Lei4Pt4jy39+UuPeAVFPeclrrCfxyL1wQ2xPrhd/saTHSL6DoJg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.8.3.tgz",
+			"integrity": "sha512-9yjUfOFN7wrYsXt/T/gEWfvVxKlnh3yBpnScw98IF+oOeCYb5/b/+K7YNqKROV2i1DlMjg9g/EcN9wvj+NkMuQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -172,9 +172,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.6.4.tgz",
-			"integrity": "sha512-qTWhuIw+/ePvOkjE9Zxf5OqSCYxtAvcTJtVmZT8YQnmY2I62JKNV2m7tf6O5ViKZUOP0mOQ6NgqHKcHH1eT8jw==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.8.3.tgz",
+			"integrity": "sha512-I8G2QmuE1teISyT8ie1HXsjFRz9L1m5n83U1O6m30Kw+kPMPSKjag6QGUn+sXT8V+XWIZxFFBoTDEDZW2KPDDw==",
 			"cpu": [
 				"x64"
 			],
@@ -188,9 +188,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.6.4.tgz",
-			"integrity": "sha512-wqi0hr8KAx5kBO0B+m5u8QqiYFFBJOSJVSuRqTeGWW+GYLVUtXNidykNqf1JsW6jJDpbkSp2xHKE/bTlVaG2Kg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.8.3.tgz",
+			"integrity": "sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==",
 			"cpu": [
 				"x64"
 			],
@@ -204,9 +204,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.6.4.tgz",
-			"integrity": "sha512-Wp3FiEeF6v6C5qMfLkHwf4YsoNHr/n0efvoC8jCKO/kX05OXaVExj+1uVQ1eGT7Pvx0XVm/TLprRO0vq/V6UzA==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.8.3.tgz",
+			"integrity": "sha512-J+Hu9WvrBevfy06eU1Na0lpc7uR9tibm9maHynLIoAjLZpQU3IW+OKHUtyL8p6/3pT2Ju5t5emReeIS2SAxhkQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -220,9 +220,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.6.4.tgz",
-			"integrity": "sha512-mz183Di5hTSGP7KjNWEhivcP1wnHLGmOxEROvoFsIxMYtDhzJDad4k5gI/1JbmA0xe4n52vsgqo09tBhrMT/Zg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.8.3.tgz",
+			"integrity": "sha512-/PJ59vA1pnQeKahemaQf4Nyj7IKUvGQSc3Ze1uIGi+Wvr1xF7rGobSrAAG01T/gUDG21vkDsZYM03NAmPiVkqg==",
 			"cpu": [
 				"x64"
 			],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"content-type": "^1.0.4",
 				"cookie-parser": "^1.4.5",
 				"debug": "^4.3.4",
-				"dicer": "^0.3.0",
+				"dicer": "Kong/dicer",
 				"dotenv": "^16.4.0",
 				"express": "^4.17.1",
 				"har-validator": "^5.1.3",
@@ -810,8 +810,7 @@
 		},
 		"node_modules/dicer": {
 			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.1.tgz",
-			"integrity": "sha512-ObioMtXnmjYs3aRtpIJt9rgQSPCIhKVkFPip+E9GUDyWl8N435znUxK/JfNwGZJ2wnn5JKQ7Ly3vOK5Q5dylGA==",
+			"resolved": "git+ssh://git@github.com/Kong/dicer.git#e41e598169ab94db09c368c91bcd29b396d21400",
 			"dependencies": {
 				"streamsearch": "^1.1.0"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
 			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"@idio/dicer": "1.1.0",
 				"change-case": "^4.1.1",
 				"compression": "^1.7.4",
 				"content-type": "^1.0.4",
 				"cookie-parser": "^1.4.5",
 				"debug": "^4.3.4",
-				"dicer": "Kong/dicer",
 				"dotenv": "^16.4.0",
 				"express": "^4.17.1",
 				"har-validator": "^5.1.3",
@@ -234,6 +234,11 @@
 			"engines": {
 				"node": ">=14.21.3"
 			}
+		},
+		"node_modules/@idio/dicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@idio/dicer/-/dicer-1.1.0.tgz",
+			"integrity": "sha512-GWro5lIxHrQPWkNlUFi1IPBWR/bJT9HuJlhJTN5KA5oyRKgcDJRaB5Js9O1no1SDsAFxEVm6QT/pgOAgR03vRg=="
 		},
 		"node_modules/@redis/bloom": {
 			"version": "1.2.0",
@@ -806,16 +811,6 @@
 			"engines": {
 				"node": ">= 0.8",
 				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"node_modules/dicer": {
-			"version": "0.3.1",
-			"resolved": "git+ssh://git@github.com/Kong/dicer.git#e41e598169ab94db09c368c91bcd29b396d21400",
-			"dependencies": {
-				"streamsearch": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/diff": {
@@ -2465,14 +2460,6 @@
 			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/streamsearch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/strip-json-comments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -413,12 +413,12 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
 			"dependencies": {
 				"bytes": "3.1.2",
-				"content-type": "~1.0.4",
+				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"destroy": "1.2.0",
@@ -426,7 +426,7 @@
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
 				"qs": "6.11.0",
-				"raw-body": "2.5.1",
+				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
 			},
@@ -478,6 +478,18 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/browser-stdout": {
 			"version": "1.3.1",
 			"dev": true,
@@ -491,13 +503,18 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
 			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.1",
-				"set-function-length": "^1.1.1"
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -571,30 +588,6 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/chokidar/node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-			"dev": true,
-			"dependencies": {
-				"fill-range": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/chokidar/node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"dev": true,
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/chokidar/node_modules/glob-parent": {
@@ -733,8 +726,9 @@
 			]
 		},
 		"node_modules/content-type": {
-			"version": "1.0.4",
-			"license": "MIT",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -783,16 +777,19 @@
 			"license": "MIT"
 		},
 		"node_modules/define-data-property": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"dependencies": {
-				"get-intrinsic": "^1.2.1",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/depd": {
@@ -867,6 +864,25 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dependencies": {
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
 			"dev": true,
@@ -889,16 +905,16 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.18.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-			"integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+			"version": "4.19.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+			"integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.1",
+				"body-parser": "1.20.2",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.5.0",
+				"cookie": "0.6.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -930,9 +946,9 @@
 			}
 		},
 		"node_modules/express/node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -989,6 +1005,18 @@
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"license": "MIT"
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/finalhandler": {
 			"version": "1.2.0",
@@ -1094,14 +1122,18 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
 			"dependencies": {
+				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
 				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1175,20 +1207,20 @@
 			}
 		},
 		"node_modules/has-property-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dependencies": {
-				"get-intrinsic": "^1.2.2"
+				"es-define-property": "^1.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -1259,7 +1291,8 @@
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			},
@@ -1320,6 +1353,15 @@
 			"dependencies": {
 				"acorn": "^7.1.1",
 				"object-assign": "^4.1.1"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/is-promise": {
@@ -1886,9 +1928,12 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -2147,9 +2192,9 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
 			"dependencies": {
 				"bytes": "3.1.2",
 				"http-errors": "2.0.0",
@@ -2222,7 +2267,8 @@
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"node_modules/send": {
 			"version": "0.18.0",
@@ -2317,14 +2363,16 @@
 			}
 		},
 		"node_modules/set-function-length": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"dependencies": {
-				"define-data-property": "^1.1.1",
-				"get-intrinsic": "^1.2.1",
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"has-property-descriptors": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -2384,13 +2432,17 @@
 			"license": "MIT"
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
 			"dependencies": {
-				"call-bind": "^1.0.0",
-				"get-intrinsic": "^1.0.2",
-				"object-inspect": "^1.9.0"
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2465,15 +2517,6 @@
 			},
 			"engines": {
 				"node": ">=8.0"
-			}
-		},
-		"node_modules/to-regex-range/node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/toidentifier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"jstransformer-marked": "^1.4.0",
 				"method-override": "^3.0.0",
 				"morgan": "^1.9.1",
-				"pug": "^2.0.4",
+				"pug": "^3.0.3",
 				"redis": "^4.6.12",
 				"require-directory": "^2.1.1",
 				"uuid": "^8.3.2",
@@ -39,6 +39,46 @@
 			},
 			"engines": {
 				"node": ">=22"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+			"integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+			"integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+			"integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"to-fast-properties": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -249,17 +289,6 @@
 				"@redis/client": "^1.0.0"
 			}
 		},
-		"node_modules/@types/babel-types": {
-			"version": "7.0.7",
-			"license": "MIT"
-		},
-		"node_modules/@types/babylon": {
-			"version": "6.16.5",
-			"license": "MIT",
-			"dependencies": {
-				"@types/babel-types": "*"
-			}
-		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -270,6 +299,17 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -285,18 +325,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/align-text": {
-			"version": "0.1.4",
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -375,33 +403,25 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/babel-runtime": {
-			"version": "6.26.0",
-			"license": "MIT",
+		"node_modules/asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+		},
+		"node_modules/assert-never": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+			"integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
+		},
+		"node_modules/babel-walk": {
+			"version": "3.0.0-canary-5",
+			"resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+			"integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
 			"dependencies": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			}
-		},
-		"node_modules/babel-runtime/node_modules/regenerator-runtime": {
-			"version": "0.11.1",
-			"license": "MIT"
-		},
-		"node_modules/babel-types": {
-			"version": "6.26.0",
-			"license": "MIT",
-			"dependencies": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
-			}
-		},
-		"node_modules/babylon": {
-			"version": "6.18.0",
-			"license": "MIT",
-			"bin": {
-				"babylon": "bin/babylon.js"
+				"@babel/types": "^7.9.6"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -538,13 +558,6 @@
 				"tslib": "^1.10.0"
 			}
 		},
-		"node_modules/camelcase": {
-			"version": "1.2.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/capital-case": {
 			"version": "1.0.3",
 			"license": "MIT",
@@ -552,17 +565,6 @@
 				"no-case": "^3.0.3",
 				"tslib": "^1.10.0",
 				"upper-case-first": "^2.0.1"
-			}
-		},
-		"node_modules/center-align": {
-			"version": "0.1.3",
-			"license": "MIT",
-			"dependencies": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/change-case": {
@@ -581,6 +583,14 @@
 				"sentence-case": "^3.0.3",
 				"snake-case": "^3.0.3",
 				"tslib": "^1.10.0"
+			}
+		},
+		"node_modules/character-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+			"integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
+			"dependencies": {
+				"is-regex": "^1.0.3"
 			}
 		},
 		"node_modules/chokidar": {
@@ -676,22 +686,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/cliui": {
-			"version": "2.1.0",
-			"license": "ISC",
-			"dependencies": {
-				"center-align": "^0.1.1",
-				"right-align": "^0.1.1",
-				"wordwrap": "0.0.2"
-			}
-		},
-		"node_modules/cliui/node_modules/wordwrap": {
-			"version": "0.0.2",
-			"license": "MIT/X11",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/cluster-key-slot": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -747,13 +741,12 @@
 			}
 		},
 		"node_modules/constantinople": {
-			"version": "3.1.2",
-			"license": "MIT",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
+			"integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
 			"dependencies": {
-				"@types/babel-types": "^7.0.0",
-				"@types/babylon": "^6.16.2",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0"
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.1"
 			}
 		},
 		"node_modules/content-disposition": {
@@ -817,11 +810,6 @@
 			"version": "1.0.6",
 			"license": "MIT"
 		},
-		"node_modules/core-js": {
-			"version": "2.6.11",
-			"hasInstallScript": true,
-			"license": "MIT"
-		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"license": "MIT",
@@ -840,13 +828,6 @@
 		"node_modules/debug/node_modules/ms": {
 			"version": "2.1.2",
 			"license": "MIT"
-		},
-		"node_modules/decamelize": {
-			"version": "1.2.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/deep-equal": {
 			"version": "1.1.1",
@@ -924,7 +905,8 @@
 		},
 		"node_modules/doctypes": {
 			"version": "1.1.0",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+			"integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="
 		},
 		"node_modules/dot-case": {
 			"version": "3.0.3",
@@ -1007,13 +989,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-		},
-		"node_modules/esutils": {
-			"version": "2.0.3",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/etag": {
 			"version": "1.8.1",
@@ -1454,9 +1429,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -1596,6 +1571,20 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-core-module": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+			"integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-date-object": {
 			"version": "1.0.2",
 			"license": "MIT",
@@ -1624,21 +1613,12 @@
 			}
 		},
 		"node_modules/is-expression": {
-			"version": "3.0.0",
-			"license": "MIT",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+			"integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
 			"dependencies": {
-				"acorn": "~4.0.2",
-				"object-assign": "^4.0.1"
-			}
-		},
-		"node_modules/is-expression/node_modules/acorn": {
-			"version": "4.0.13",
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
+				"acorn": "^7.1.1",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"node_modules/is-extendable": {
@@ -1703,8 +1683,9 @@
 			}
 		},
 		"node_modules/is-promise": {
-			"version": "2.1.0",
-			"license": "MIT"
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
 		},
 		"node_modules/is-regex": {
 			"version": "1.0.5",
@@ -1760,11 +1741,21 @@
 		},
 		"node_modules/js-stringify": {
 			"version": "1.0.2",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+			"integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g=="
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"license": "MIT"
+		},
+		"node_modules/jstransformer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
+			"integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
+			"dependencies": {
+				"is-promise": "^2.0.0",
+				"promise": "^7.0.1"
+			}
 		},
 		"node_modules/jstransformer-marked": {
 			"version": "1.4.0",
@@ -1802,11 +1793,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
@@ -1883,13 +1869,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/longest": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/lower-case": {
@@ -2357,7 +2336,8 @@
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2486,6 +2466,11 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+		},
 		"node_modules/path-to-regexp": {
 			"version": "0.1.7",
 			"license": "MIT"
@@ -2509,6 +2494,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dependencies": {
+				"asap": "~2.0.3"
+			}
+		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2522,209 +2515,116 @@
 			}
 		},
 		"node_modules/pug": {
-			"version": "2.0.4",
-			"license": "MIT",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
+			"integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
 			"dependencies": {
-				"pug-code-gen": "^2.0.2",
-				"pug-filters": "^3.1.1",
-				"pug-lexer": "^4.1.0",
-				"pug-linker": "^3.0.6",
-				"pug-load": "^2.0.12",
-				"pug-parser": "^5.0.1",
-				"pug-runtime": "^2.0.5",
-				"pug-strip-comments": "^1.0.4"
+				"pug-code-gen": "^3.0.3",
+				"pug-filters": "^4.0.0",
+				"pug-lexer": "^5.0.1",
+				"pug-linker": "^4.0.0",
+				"pug-load": "^3.0.0",
+				"pug-parser": "^6.0.0",
+				"pug-runtime": "^3.0.1",
+				"pug-strip-comments": "^2.0.0"
 			}
 		},
 		"node_modules/pug-attrs": {
-			"version": "2.0.4",
-			"license": "MIT",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
+			"integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
 			"dependencies": {
-				"constantinople": "^3.0.1",
-				"js-stringify": "^1.0.1",
-				"pug-runtime": "^2.0.5"
+				"constantinople": "^4.0.1",
+				"js-stringify": "^1.0.2",
+				"pug-runtime": "^3.0.0"
 			}
 		},
 		"node_modules/pug-code-gen": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.3.tgz",
-			"integrity": "sha512-r9sezXdDuZJfW9J91TN/2LFbiqDhmltTFmGpHTsGdrNGp3p4SxAjjXEfnuK2e4ywYsRIVP0NeLbSAMHUcaX1EA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
+			"integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
 			"dependencies": {
-				"constantinople": "^3.1.2",
+				"constantinople": "^4.0.1",
 				"doctypes": "^1.1.0",
-				"js-stringify": "^1.0.1",
-				"pug-attrs": "^2.0.4",
-				"pug-error": "^1.3.3",
-				"pug-runtime": "^2.0.5",
-				"void-elements": "^2.0.1",
-				"with": "^5.0.0"
-			}
-		},
-		"node_modules/pug-code-gen/node_modules/acorn": {
-			"version": "3.3.0",
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/pug-code-gen/node_modules/acorn-globals": {
-			"version": "3.1.0",
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^4.0.4"
-			}
-		},
-		"node_modules/pug-code-gen/node_modules/acorn-globals/node_modules/acorn": {
-			"version": "4.0.13",
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/pug-code-gen/node_modules/with": {
-			"version": "5.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^3.1.0",
-				"acorn-globals": "^3.0.0"
+				"js-stringify": "^1.0.2",
+				"pug-attrs": "^3.0.0",
+				"pug-error": "^2.1.0",
+				"pug-runtime": "^3.0.1",
+				"void-elements": "^3.1.0",
+				"with": "^7.0.0"
 			}
 		},
 		"node_modules/pug-error": {
-			"version": "1.3.3",
-			"license": "MIT"
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
+			"integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg=="
 		},
 		"node_modules/pug-filters": {
-			"version": "3.1.1",
-			"license": "MIT",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
+			"integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
 			"dependencies": {
-				"clean-css": "^4.1.11",
-				"constantinople": "^3.0.1",
+				"constantinople": "^4.0.1",
 				"jstransformer": "1.0.0",
-				"pug-error": "^1.3.3",
-				"pug-walk": "^1.1.8",
-				"resolve": "^1.1.6",
-				"uglify-js": "^2.6.1"
-			}
-		},
-		"node_modules/pug-filters/node_modules/asap": {
-			"version": "2.0.6",
-			"license": "MIT"
-		},
-		"node_modules/pug-filters/node_modules/clean-css": {
-			"version": "4.2.3",
-			"license": "MIT",
-			"dependencies": {
-				"source-map": "~0.6.0"
-			},
-			"engines": {
-				"node": ">= 4.0"
-			}
-		},
-		"node_modules/pug-filters/node_modules/jstransformer": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"is-promise": "^2.0.0",
-				"promise": "^7.0.1"
-			}
-		},
-		"node_modules/pug-filters/node_modules/promise": {
-			"version": "7.3.1",
-			"license": "MIT",
-			"dependencies": {
-				"asap": "~2.0.3"
-			}
-		},
-		"node_modules/pug-filters/node_modules/source-map": {
-			"version": "0.6.1",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pug-filters/node_modules/uglify-js": {
-			"version": "2.8.29",
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"source-map": "~0.5.1",
-				"yargs": "~3.10.0"
-			},
-			"bin": {
-				"uglifyjs": "bin/uglifyjs"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			},
-			"optionalDependencies": {
-				"uglify-to-browserify": "~1.0.0"
-			}
-		},
-		"node_modules/pug-filters/node_modules/uglify-js/node_modules/source-map": {
-			"version": "0.5.7",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
+				"pug-error": "^2.0.0",
+				"pug-walk": "^2.0.0",
+				"resolve": "^1.15.1"
 			}
 		},
 		"node_modules/pug-lexer": {
-			"version": "4.1.0",
-			"license": "MIT",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+			"integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
 			"dependencies": {
-				"character-parser": "^2.1.1",
-				"is-expression": "^3.0.0",
-				"pug-error": "^1.3.3"
-			}
-		},
-		"node_modules/pug-lexer/node_modules/character-parser": {
-			"version": "2.2.0",
-			"license": "MIT",
-			"dependencies": {
-				"is-regex": "^1.0.3"
+				"character-parser": "^2.2.0",
+				"is-expression": "^4.0.0",
+				"pug-error": "^2.0.0"
 			}
 		},
 		"node_modules/pug-linker": {
-			"version": "3.0.6",
-			"license": "MIT",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
+			"integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
 			"dependencies": {
-				"pug-error": "^1.3.3",
-				"pug-walk": "^1.1.8"
+				"pug-error": "^2.0.0",
+				"pug-walk": "^2.0.0"
 			}
 		},
 		"node_modules/pug-load": {
-			"version": "2.0.12",
-			"license": "MIT",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
+			"integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
 			"dependencies": {
-				"object-assign": "^4.1.0",
-				"pug-walk": "^1.1.8"
+				"object-assign": "^4.1.1",
+				"pug-walk": "^2.0.0"
 			}
 		},
 		"node_modules/pug-parser": {
-			"version": "5.0.1",
-			"license": "MIT",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
+			"integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
 			"dependencies": {
-				"pug-error": "^1.3.3",
-				"token-stream": "0.0.1"
+				"pug-error": "^2.0.0",
+				"token-stream": "1.0.0"
 			}
 		},
 		"node_modules/pug-runtime": {
-			"version": "2.0.5",
-			"license": "MIT"
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
+			"integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg=="
 		},
 		"node_modules/pug-strip-comments": {
-			"version": "1.0.4",
-			"license": "MIT",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
+			"integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
 			"dependencies": {
-				"pug-error": "^1.3.3"
+				"pug-error": "^2.0.0"
 			}
 		},
 		"node_modules/pug-walk": {
-			"version": "1.1.8",
-			"license": "MIT"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
+			"integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="
 		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
@@ -2887,17 +2787,19 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.1.7",
-			"license": "MIT"
-		},
-		"node_modules/right-align": {
-			"version": "0.1.3",
-			"license": "MIT",
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dependencies": {
-				"align-text": "^0.1.1"
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
-			"engines": {
-				"node": ">=0.10.0"
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -3148,11 +3050,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/to-fast-properties": {
-			"version": "1.0.3",
-			"license": "MIT",
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/to-file-path": {
@@ -3195,8 +3109,9 @@
 			}
 		},
 		"node_modules/token-stream": {
-			"version": "0.0.1",
-			"license": "MIT"
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
+			"integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg=="
 		},
 		"node_modules/tslib": {
 			"version": "1.11.1",
@@ -3213,11 +3128,6 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
-		},
-		"node_modules/uglify-to-browserify": {
-			"version": "1.0.2",
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
@@ -3270,16 +3180,25 @@
 			}
 		},
 		"node_modules/void-elements": {
-			"version": "2.0.1",
-			"license": "MIT",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+			"integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/window-size": {
-			"version": "0.1.0",
+		"node_modules/with": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
+			"integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
+			"dependencies": {
+				"@babel/parser": "^7.9.6",
+				"@babel/types": "^7.9.6",
+				"assert-never": "^1.2.1",
+				"babel-walk": "3.0.0-canary-5"
+			},
 			"engines": {
-				"node": ">= 0.8.0"
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/workerpool": {
@@ -3414,16 +3333,6 @@
 			"bin": {
 				"json2yaml": "bin/json2yaml",
 				"yaml2json": "bin/yaml2json"
-			}
-		},
-		"node_modules/yargs": {
-			"version": "3.10.0",
-			"license": "MIT",
-			"dependencies": {
-				"camelcase": "^1.0.2",
-				"cliui": "^2.1.0",
-				"decamelize": "^1.0.0",
-				"window-size": "0.1.0"
 			}
 		},
 		"node_modules/yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,15 @@
 		"testing"
 	],
 	"engines": {
-		"node": ">=21"
+		"node": ">=22"
 	},
-	"files": ["bin", "docs", "src", "lib", "server.js"],
+	"files": [
+		"bin",
+		"docs",
+		"src",
+		"lib",
+		"server.js"
+	],
 	"bugs": {
 		"url": "https://github.com/Kong/mockbin/issues"
 	},

--- a/package.json
+++ b/package.json
@@ -25,13 +25,7 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"files": [
-		"bin",
-		"docs",
-		"src",
-		"lib",
-		"server.js"
-	],
+	"files": ["bin", "docs", "src", "lib", "server.js"],
 	"bugs": {
 		"url": "https://github.com/Kong/mockbin/issues"
 	},

--- a/package.json
+++ b/package.json
@@ -25,7 +25,13 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"files": ["bin", "docs", "src", "lib", "server.js"],
+	"files": [
+		"bin",
+		"docs",
+		"src",
+		"lib",
+		"server.js"
+	],
 	"bugs": {
 		"url": "https://github.com/Kong/mockbin/issues"
 	},
@@ -48,7 +54,7 @@
 		"content-type": "^1.0.4",
 		"cookie-parser": "^1.4.5",
 		"debug": "^4.3.4",
-		"dicer": "Kong/dicer",
+		"@idio/dicer": "1.1.0",
 		"dotenv": "^16.4.0",
 		"express": "^4.17.1",
 		"har-validator": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
 		"dicer": "^0.3.0",
 		"dotenv": "^16.4.0",
 		"express": "^4.17.1",
-		"forwarded-http": "^0.3.0",
 		"har-validator": "^5.1.3",
 		"jstransformer-marked": "^1.4.0",
 		"method-override": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"content-type": "^1.0.4",
 		"cookie-parser": "^1.4.5",
 		"debug": "^4.3.4",
-		"dicer": "^0.3.0",
+		"dicer": "Kong/dicer",
 		"dotenv": "^16.4.0",
 		"express": "^4.17.1",
 		"har-validator": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"clean": "git clean -fdX"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.6.4",
+		"@biomejs/biome": "1.8.3",
 		"mocha": "^10.2.0",
 		"should": "^13.2.3"
 	},

--- a/package.json
+++ b/package.json
@@ -25,20 +25,9 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"files": [
-		"bin",
-		"docs",
-		"src",
-		"lib",
-		"server.js"
-	],
+	"files": ["bin", "docs", "src", "lib", "server.js"],
 	"bugs": {
 		"url": "https://github.com/Kong/mockbin/issues"
-	},
-	"config": {
-		"commitizen": {
-			"path": "./node_modules/cz-conventional-changelog"
-		}
 	},
 	"scripts": {
 		"start": "node server.js",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"jstransformer-marked": "^1.4.0",
 		"method-override": "^3.0.0",
 		"morgan": "^1.9.1",
-		"pug": "^2.0.4",
+		"pug": "^3.0.3",
 		"redis": "^4.6.12",
 		"require-directory": "^2.1.1",
 		"uuid": "^8.3.2",

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@ with import <nixpkgs> { };
 
 mkShell {
   nativeBuildInputs = [
-    nodejs_21
+    nodejs_22
     biome
   ];
   BIOME_BINARY = "${biome}/bin/biome";

--- a/test/http/index.js
+++ b/test/http/index.js
@@ -11,11 +11,13 @@ app.set("views", path.join(__dirname, "..", "..", "src", "views"));
 app.use(cookieParser());
 
 app.use("/", mockbin());
-server = app.listen(3000);
 
 require("should");
 
 describe("HTTP", () => {
+	before(()=>{
+		server = app.listen(3000);
+	})
 	after(() => {
     server.close();
   });
@@ -65,19 +67,6 @@ describe("HTTP", () => {
 
 		const body = await res.text();
 		body.should.equal("::1");
-	});
-
-	it("GET /ips should return proxied IPs", async () => {
-		const res = await fetch("http://localhost:3000/ips", {
-			headers: {
-				Accept: "application/json",
-				"X-Forwarded-For": "10.10.10.1, 10.10.10.2, 10.10.10.3",
-			},
-		});
-
-		const body = await res.json();
-		body.should.be.an.Object();
-		body.should.have.properties("10.10.10.1", "10.10.10.2", "10.10.10.3");
 	});
 
 	it("GET /agent should return user-agent string", async () => {

--- a/test/http/index.js
+++ b/test/http/index.js
@@ -4,29 +4,21 @@ const mockbin = require("../../lib");
 const path = require("node:path");
 
 const app = express();
-let server = null;
+app.enable("trust proxy");
+app.set("view engine", "pug");
+app.set("views", path.join(__dirname, "..", "..", "src", "views"));
+
+app.use(cookieParser());
+
+app.use("/", mockbin());
+server = app.listen(3000);
 
 require("should");
 
 describe("HTTP", () => {
-	before((done) => {
-		// express setup
-		app.enable("trust proxy");
-		app.set("view engine", "pug");
-		app.set("views", path.join(__dirname, "..", "..", "src", "views"));
-
-		app.use(cookieParser());
-
-		app.use("/", mockbin());
-		server = app.listen(3000, () => {
-			done();
-		});
-	});
-
 	after(() => {
-		server.close();
-	});
-
+    server.close();
+  });
 	it("home page responds with html content", async () => {
 		const res = await fetch("http://localhost:3000/", {
 			headers: {

--- a/test/http/index.js
+++ b/test/http/index.js
@@ -15,12 +15,12 @@ app.use("/", mockbin());
 require("should");
 
 describe("HTTP", () => {
-	before(()=>{
+	before(() => {
 		server = app.listen(3000);
-	})
+	});
 	after(() => {
-    server.close();
-  });
+		server.close();
+	});
 	it("home page responds with html content", async () => {
 		const res = await fetch("http://localhost:3000/", {
 			headers: {

--- a/test/routes/ips.js
+++ b/test/routes/ips.js
@@ -18,23 +18,3 @@ describe("/ip", () => {
 		});
 	});
 });
-
-describe("/ips", () => {
-	it("should response with all address", (done) => {
-		const res = {};
-		const req = {
-			forwarded: {
-				for: {
-					"0.0.0.0": -1,
-					"1.1.1.1": -1,
-				},
-			},
-		};
-
-		ips.all(req, res, () => {
-			res.body.should.equal(req.forwarded.for);
-
-			done();
-		});
-	});
-});


### PR DESCRIPTION
- [x] bump node 22
- [x] bump biome
- [x] bump pug to v3
- [x] add npm audit to CI
- [x] remove forwarded-http and `/ips`
- [x] use fork of dicer -> @idio/dicer

Since the forwarded-http behavior was only supporting the `/ips` endpoint which listed ip addresses in a the X-Forwarded-for header field. It seems like something we could cut to avoid the vulnerability, if we later find a use case for this we can reimplement it.

Taking ownership of forwarded-http would also mean taking ownership of its dependencies which is a rabbit hole this feature has not earned.

https://github.com/mscdex/dicer/pull/22