### PR TITLE
feat: Add support for redis memorystore instance with in-transit encryption

### DIFF
--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -14,6 +14,9 @@ module.exports = function bins(dsnStr) {
 		legacyMode: true,
 		url: dsnStr,
 		no_ready_check: true,
+		tls: {
+			rejectUnauthorized: false
+		},
 	});
 
 	// Disable client's AUTH command.

--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -15,7 +15,7 @@ module.exports = function bins(dsnStr) {
 		url: dsnStr,
 		no_ready_check: true,
 		tls: {
-			rejectUnauthorized: false
+			rejectUnauthorized: false,
 		},
 	});
 


### PR DESCRIPTION
* Enable tls connections to Memorystore redis instance
* Skip verification for tests until rest of the changes are complete