### PR TITLE
fix: Add Docker Hub login to avoid build failures due to image pull rate limit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,8 +83,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb # v2.1.0
         with:
-          username: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}
-          password: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUSH_TOKEN }}
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
       # Build Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,14 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           sep-tags: ","
 
+      # Login to Docker Hub to avoid image pull ratelimit failures on build step
+      # https://github.com/docker/login-action
+      - name: Login to Docker Hub
+        uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb # v2.1.0
+        with:
+          username: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}
+          password: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUSH_TOKEN }}
+
       # Build Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build Docker image


### PR DESCRIPTION
* Include a docker hub login step to avoid image pull issues during the container image build stage