### PR TITLE
Block unused endpoints in cloud mock

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
+	"files": {
+		"ignore": ["package.json", "package-lock.json"]
+	},
 	"organizeImports": {
 		"enabled": true
 	},

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,43 +6,46 @@ const routes = require("./routes");
 module.exports = function (options) {
 	const router = express.Router();
 
-	const endpoints = [
-		{ action: "get", path: "/", route: routes.hello },
-		{ action: "all", path: "/ip", route: routes.ips.one },
-		{ action: "all", path: "/agent", route: routes.headers.agent },
-		{ action: "all", path: "/status/:code/:reason?", route: routes.status },
-		{ action: "all", path: "/headers", route: routes.headers.all },
-		{ action: "all", path: "/header/:name", route: routes.headers.one },
-		{ action: "all", path: "/header/:name/:value", route: routes.headers.set },
-		{ action: "all", path: "/cookies", route: routes.cookies.all },
-		{ action: "all", path: "/cookie/:name", route: routes.cookies.one },
-		{ action: "all", path: "/cookie/:name/:value", route: routes.cookies.set },
-		{
-			action: "all",
-			path: "/redirect/:status_code/:count?",
-			route: routes.redirect,
-		},
-		{ action: "all", path: "/delay/:ms?", route: routes.delay },
-		{ action: "all", path: "/stream/:chunks?", route: routes.stream },
-		{ action: "all", path: "/har*", route: routes.har },
-		{ action: "all", path: "/echo*", route: routes.echo },
-		{ action: "all", path: "/request*", route: routes.request },
-	];
+	// Only expose necessary routes if running in cloud mock
+	if (process.env.MOCKBIN_IS_CLOUD_MOCK !== "true") {
+		const endpoints = [
+			{ action: "get", path: "/", route: routes.hello },
+			{ action: "all", path: "/ip", route: routes.ips.one },
+			{ action: "all", path: "/agent", route: routes.headers.agent },
+			{ action: "all", path: "/status/:code/:reason?", route: routes.status },
+			{ action: "all", path: "/headers", route: routes.headers.all },
+			{ action: "all", path: "/header/:name", route: routes.headers.one },
+			{ action: "all", path: "/header/:name/:value", route: routes.headers.set },
+			{ action: "all", path: "/cookies", route: routes.cookies.all },
+			{ action: "all", path: "/cookie/:name", route: routes.cookies.one },
+			{ action: "all", path: "/cookie/:name/:value", route: routes.cookies.set },
+			{
+				action: "all",
+				path: "/redirect/:status_code/:count?",
+				route: routes.redirect,
+			},
+			{ action: "all", path: "/delay/:ms?", route: routes.delay },
+			{ action: "all", path: "/stream/:chunks?", route: routes.stream },
+			{ action: "all", path: "/har*", route: routes.har },
+			{ action: "all", path: "/echo*", route: routes.echo },
+			{ action: "all", path: "/request*", route: routes.request },
+		];
 
-	endpoints.forEach((endpoint) => {
-		// assign router to action at path
-		router[endpoint.action].apply(
-			router,
-			[endpoint.path].concat([
-				mw.errorHandler,
-				mw.bodyParser,
-				endpoint.route,
-				mw.cors,
-				mw.poweredBy,
-				mw.negotiateContent,
-			]),
-		);
-	});
+		endpoints.forEach((endpoint) => {
+			// assign router to action at path
+			router[endpoint.action].apply(
+				router,
+				[endpoint.path].concat([
+					mw.errorHandler,
+					mw.bodyParser,
+					endpoint.route,
+					mw.cors,
+					mw.poweredBy,
+					mw.negotiateContent,
+				]),
+			);
+		});
+	}
 
 	if (options?.redis) {
 		router.use("/bin", routes.bins(options.redis));

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,10 +15,18 @@ module.exports = function (options) {
 			{ action: "all", path: "/status/:code/:reason?", route: routes.status },
 			{ action: "all", path: "/headers", route: routes.headers.all },
 			{ action: "all", path: "/header/:name", route: routes.headers.one },
-			{ action: "all", path: "/header/:name/:value", route: routes.headers.set },
+			{
+				action: "all",
+				path: "/header/:name/:value",
+				route: routes.headers.set,
+			},
 			{ action: "all", path: "/cookies", route: routes.cookies.all },
 			{ action: "all", path: "/cookie/:name", route: routes.cookies.one },
-			{ action: "all", path: "/cookie/:name/:value", route: routes.cookies.set },
+			{
+				action: "all",
+				path: "/cookie/:name/:value",
+				route: routes.cookies.set,
+			},
 			{
 				action: "all",
 				path: "/redirect/:status_code/:count?",

--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -36,6 +36,11 @@ module.exports = function bins(dsnStr) {
 			route: routes.log(client),
 		},
 		{ action: "put", path: "/upsert/:uuid*", route: routes.update(client) },
+		{
+			action: "delete",
+			path: "/delete/:uuid*",
+			route: routes.delete(client),
+		},
 		// make sure this is the last route
 		{ action: "all", path: "/:uuid*", route: routes.run(client) },
 	];
@@ -59,11 +64,6 @@ module.exports = function bins(dsnStr) {
 				action: "get",
 				path: "/sample/:uuid*",
 				route: routes.sample(client),
-			},
-			{
-				action: "delete",
-				path: "/delete/:uuid*",
-				route: routes.delete(client),
 			},
 		);
 	}

--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -30,35 +30,43 @@ module.exports = function bins(dsnStr) {
 	const router = express.Router();
 
 	const endpoints = [
-		{ action: "get", path: "/create", route: routes.form },
-		{
-			action: "post",
-			path: "/create",
-			route: routes.create(client),
-		},
-		{
-			action: "get",
-			path: "/view/:uuid*",
-			route: routes.view(client),
-		},
-		{
-			action: "get",
-			path: "/sample/:uuid*",
-			route: routes.sample(client),
-		},
 		{
 			action: "get",
 			path: "/log/:uuid*",
 			route: routes.log(client),
 		},
-		{
-			action: "delete",
-			path: "/delete/:uuid*",
-			route: routes.delete(client),
-		},
 		{ action: "put", path: "/upsert/:uuid*", route: routes.update(client) },
+		// make sure this is the last route
 		{ action: "all", path: "/:uuid*", route: routes.run(client) },
 	];
+
+	// Only expose necessary routes if running in cloud mock
+	if (process.env.MOCKBIN_IS_CLOUD_MOCK !== "true") {
+		// use unshift to add extra routes at the beginning to keep the last one in endpoints unchanged
+		endpoints.unshift(
+			{ action: "get", path: "/create", route: routes.form },
+			{
+				action: "post",
+				path: "/create",
+				route: routes.create(client),
+			},
+			{
+				action: "get",
+				path: "/view/:uuid*",
+				route: routes.view(client),
+			},
+			{
+				action: "get",
+				path: "/sample/:uuid*",
+				route: routes.sample(client),
+			},
+			{
+				action: "delete",
+				path: "/delete/:uuid*",
+				route: routes.delete(client),
+			},
+		);
+	}
 
 	endpoints.forEach((endpoint) => {
 		// assign router to action at path

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mockbin",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mockbin",
-			"version": "2.0.4",
+			"version": "2.0.5",
 			"license": "MIT",
 			"dependencies": {
 				"@idio/dicer": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mockbin",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mockbin",
-			"version": "2.0.6",
+			"version": "2.0.7",
 			"license": "MIT",
 			"dependencies": {
 				"@idio/dicer": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mockbin",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mockbin",
-			"version": "2.0.3",
+			"version": "2.0.4",
 			"license": "MIT",
 			"dependencies": {
 				"@idio/dicer": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mockbin",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mockbin",
-			"version": "2.0.5",
+			"version": "2.0.6",
 			"license": "MIT",
 			"dependencies": {
 				"@idio/dicer": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,7 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"files": [
-		"bin",
-		"docs",
-		"src",
-		"lib",
-		"server.js"
-	],
+	"files": ["bin", "docs", "src", "lib", "server.js"],
 	"bugs": {
 		"url": "https://github.com/Kong/mockbin/issues"
 	},

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"name": "mockbin",
 	"description": "Test, mock, and track HTTP requests & responses between libraries, sockets and APIs",
 	"author": "Kong (https://www.konghq.com/)",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"name": "mockbin",
 	"description": "Test, mock, and track HTTP requests & responses between libraries, sockets and APIs",
 	"author": "Kong (https://www.konghq.com/)",
@@ -25,7 +25,13 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"files": ["bin", "docs", "src", "lib", "server.js"],
+	"files": [
+		"bin",
+		"docs",
+		"src",
+		"lib",
+		"server.js"
+	],
 	"bugs": {
 		"url": "https://github.com/Kong/mockbin/issues"
 	},

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"name": "mockbin",
 	"description": "Test, mock, and track HTTP requests & responses between libraries, sockets and APIs",
 	"author": "Kong (https://www.konghq.com/)",
@@ -25,7 +25,13 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"files": ["bin", "docs", "src", "lib", "server.js"],
+	"files": [
+		"bin",
+		"docs",
+		"src",
+		"lib",
+		"server.js"
+	],
 	"bugs": {
 		"url": "https://github.com/Kong/mockbin/issues"
 	},

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"name": "mockbin",
 	"description": "Test, mock, and track HTTP requests & responses between libraries, sockets and APIs",
 	"author": "Kong (https://www.konghq.com/)",
@@ -25,7 +25,13 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"files": ["bin", "docs", "src", "lib", "server.js"],
+	"files": [
+		"bin",
+		"docs",
+		"src",
+		"lib",
+		"server.js"
+	],
 	"bugs": {
 		"url": "https://github.com/Kong/mockbin/issues"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -41,21 +41,7 @@ module.exports = (options, done) => {
 	// magic starts here
 	app.use("/", router(options));
 	app.use("/healthcheck", (req, res) => {
-		res.set({ "Content-Type": "application/json; charset=utf-8" });
-		res.send(
-			JSON.stringify(
-				{
-					name: process.env.npm_package_name,
-					version: process.env.npm_package_version,
-					uptimeSeconds: process.uptime(),
-					memory: process.memoryUsage(),
-					pid: process.pid,
-					versions: process.versions,
-				},
-				null,
-				2,
-			),
-		);
+		res.status(200).send();
 	});
 
 	app.listen(options.port);


### PR DESCRIPTION
1. Use the environment variable MOCKBIN_IS_CLOUD_MOCK=true to indicate that the service is running for cloud mock.
2. Remove detailed service information returned by /healthcheck