### PR TITLE
Using node:22-alpine as the base image to address the High vulnerabil…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:22-bullseye-slim
+FROM node:22-alpine
 
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+RUN apk add --no-cache dumb-init
 ENV NODE_ENV production
 WORKDIR /usr/src/app
 COPY --chown=node:node . .


### PR DESCRIPTION
Using node:22-alpine as the base image to address the High vulnerability found in node:22-bullseye-slim.

Fix https://konghq.atlassian.net/browse/INS-901?focusedCommentId=169308