### PR TITLE
Chore: apply PoLP to Github action workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,6 @@ jobs:
   check:
     runs-on: ubuntu-24.04
     permissions:
-      packages: write
       contents: write # publish sbom to GH releases/tag assets
     steps:
       - name: Checkout repository
@@ -54,7 +53,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    # packages: write
     needs: [check]
     outputs:
       image_tags: ${{ steps.meta.outputs.tags }}
@@ -118,7 +116,7 @@ jobs:
           outputs: type=docker,dest=${{ env.DOCKER_OCI_ARCHIVE }}.tar,oci-mediatypes=true
 
       - name: Upload Docker OCI layout TAR Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.DOCKER_OCI_ARCHIVE }}
           path: ${{ env.DOCKER_OCI_ARCHIVE }}.tar
@@ -129,14 +127,13 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write # For publishing assets to releases
-      # packages: write
     needs: [check, build-images]
     if: >
       github.repository_owner == 'Kong'
       && needs.build-images.result == 'success'
     steps:
       - name: Download OCI docker TAR artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ env.DOCKER_OCI_ARCHIVE }}
           path: ${{ github.workspace }}
@@ -171,7 +168,7 @@ jobs:
       # notary_repository: ${{ env.NOTARY_REPOSITORY }}
     steps:
       - name: Download OCI docker TAR artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ env.DOCKER_OCI_ARCHIVE }}
           path: ${{ github.workspace }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,8 @@ env:
   ## docker.io/kong/notary-internal - Use Private Notary repository for internal image signatures
   # NOTARY_REPOSITORY: ${{ github.ref_type == 'tag' || github.ref_name == 'master' || 'kong/notary-internal' }}
 
+permissions: {} # Deny all GITHUB_TOKEN permissions by default.
+
 jobs:
   check:
     runs-on: ubuntu-24.04
@@ -52,7 +54,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      packages: write
+    # packages: write
     needs: [check]
     outputs:
       image_tags: ${{ steps.meta.outputs.tags }}
@@ -116,7 +118,7 @@ jobs:
           outputs: type=docker,dest=${{ env.DOCKER_OCI_ARCHIVE }}.tar,oci-mediatypes=true
 
       - name: Upload Docker OCI layout TAR Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: ${{ env.DOCKER_OCI_ARCHIVE }}
           path: ${{ env.DOCKER_OCI_ARCHIVE }}.tar
@@ -127,14 +129,14 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write # For publishing assets to releases
-      packages: write
+      # packages: write
     needs: [check, build-images]
     if: >
       github.repository_owner == 'Kong'
       && needs.build-images.result == 'success'
     steps:
       - name: Download OCI docker TAR artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: ${{ env.DOCKER_OCI_ARCHIVE }}
           path: ${{ github.workspace }}
@@ -142,7 +144,6 @@ jobs:
         run: |
           docker load -i ${{ github.workspace }}/${{ env.DOCKER_OCI_ARCHIVE }}.tar
           docker image ls
-
       - name: Scan the docker OCI Tar ball
         id: sbom_action_amd64
         uses: Kong/public-shared-actions/security-actions/scan-docker-image@29dd57c7c19389e07390c1c9fe83aef6ff0c424a # v6.1.0
@@ -170,7 +171,7 @@ jobs:
       # notary_repository: ${{ env.NOTARY_REPOSITORY }}
     steps:
       - name: Download OCI docker TAR artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: ${{ env.DOCKER_OCI_ARCHIVE }}
           path: ${{ github.workspace }}

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -21,12 +21,10 @@ jobs:
     permissions:
       # required for all workflows
       security-events: write
-      # only required for workflows in private repositories
-      # actions: read
       contents: read
 
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Kong/public-shared-actions/security-actions/semgrep@a18abf762d6e2444bcbfd20de70451ea1e3bc1b1 # v4.0.1

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -11,8 +11,7 @@ on:
     - 'v*.*.*'  
   workflow_dispatch: {}
 
-permissions:
-  contents: read
+permissions: {} # Deny all GITHUB_TOKEN permissions by default.
 
 jobs:
   semgrep:
@@ -23,11 +22,11 @@ jobs:
       # required for all workflows
       security-events: write
       # only required for workflows in private repositories
-      actions: read
+      # actions: read
       contents: read
 
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: Kong/public-shared-actions/security-actions/semgrep@a18abf762d6e2444bcbfd20de70451ea1e3bc1b1 # v4.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,11 +9,11 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 21
     - run: npm ci
-    - uses: biomejs/setup-biome@c016c38f26f2c4a6eb3662679143614a254263fd # v2
+    - uses: biomejs/setup-biome@c016c38f26f2c4a6eb3662679143614a254263fd # v2.3.0
     - run: biome ci .
     - run: npm test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,16 @@
 name: Lint & Test
 on: push
+
+permissions: {}  # top-level deny-all
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 21
     - run: npm ci


### PR DESCRIPTION
## What does this PR do?
This PR is in response to [INC-721](https://konghq.atlassian.net/browse/) and introduces the principle of least privilege (PoLP) to the Github action workflows. See [INS-2320](https://konghq.atlassian.net/browse/INS-2320) for more detail.

* New jobs are required to explicitly declare their permissions, enforcing least privilege by default.
* Existing job token permission have been reduced.
* Pinned actions using commit SHA

[INC-721]: https://konghq.atlassian.net/browse/INC-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INS-2320]: https://konghq.atlassian.net/browse/INS-2320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ