### PR TITLE
Add restrictedHeaders middleware to filter request headers

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -6,4 +6,5 @@ module.exports = {
 	negotiateContent: require("./negotiate-content"),
 	notFoundHandler: require("./not-found-handler"),
 	poweredBy: require("./powered-by"),
+	restrictedHeaders: require("./restricted-headers"),
 };

--- a/lib/middleware/restricted-headers.js
+++ b/lib/middleware/restricted-headers.js
@@ -1,0 +1,16 @@
+const getRestrictedHeaders = () => {
+	return (process.env.MOCKBIN_CLOUD_RESTRICTED_HEADERS || "")
+		.split(",")
+		.map((header) => header.trim().toLowerCase())
+		.filter(Boolean);
+};
+
+module.exports = (req, res, next) => {
+	const restrictedHeaders = getRestrictedHeaders();
+
+	for (const headerName of restrictedHeaders) {
+		delete req.headers[headerName];
+	}
+
+	next();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mockbin",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mockbin",
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"@faker-js/faker": "^9.8.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"name": "mockbin",
 	"description": "Test, mock, and track HTTP requests & responses between libraries, sockets and APIs",
 	"author": "Kong (https://www.konghq.com/)",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const methodOverride = require("method-override");
 const morgan = require("morgan");
 const path = require("node:path");
 const router = require("../lib");
-const { errorHandler } = require("../lib/middleware");
+const { errorHandler, restrictedHeaders } = require("../lib/middleware");
 
 module.exports = (options, done) => {
 	if (!options) {
@@ -23,6 +23,10 @@ module.exports = (options, done) => {
 	app.set("view engine", "pug");
 	app.set("views", path.join(__dirname, "views"));
 	app.set("jsonp callback name", "__callback");
+
+	if (process.env.MOCKBIN_IS_CLOUD_MOCK === "true") {
+		app.use(restrictedHeaders);
+	}
 
 	// add 3rd party middlewares
 	app.use(compression());

--- a/test/middleware/restricted-headers.js
+++ b/test/middleware/restricted-headers.js
@@ -1,0 +1,50 @@
+/* global describe, it */
+
+const restrictedHeaders = require("../../lib/middleware/restricted-headers");
+
+require("should");
+
+describe("restrictedHeaders", () => {
+	it("should remove configured headers from req.headers", (done) => {
+		const originalValue = process.env.MOCKBIN_CLOUD_RESTRICTED_HEADERS;
+		process.env.MOCKBIN_CLOUD_RESTRICTED_HEADERS =
+			"Proxy, Host, X-Forwarded-For";
+
+		const req = {
+			headers: {
+				proxy: "proxy-value",
+				host: "example.com",
+				"x-forwarded-for": "127.0.0.1",
+				"content-type": "application/json",
+			},
+		};
+
+		restrictedHeaders(req, {}, () => {
+			req.headers.should.not.have.property("proxy");
+			req.headers.should.not.have.property("host");
+			req.headers.should.not.have.property("x-forwarded-for");
+			req.headers.should.have.property("content-type");
+
+			process.env.MOCKBIN_CLOUD_RESTRICTED_HEADERS = originalValue;
+			done();
+		});
+	});
+
+	it("should do nothing when no restricted headers are configured", (done) => {
+		const originalValue = process.env.MOCKBIN_CLOUD_RESTRICTED_HEADERS;
+		process.env.MOCKBIN_CLOUD_RESTRICTED_HEADERS = undefined;
+
+		const req = {
+			headers: {
+				foo: "bar",
+			},
+		};
+
+		restrictedHeaders(req, {}, () => {
+			req.headers.should.have.property("foo");
+
+			process.env.MOCKBIN_CLOUD_RESTRICTED_HEADERS = originalValue;
+			done();
+		});
+	});
+});


### PR DESCRIPTION
Introduce a middleware to remove specified headers from incoming requests based on environment configuration. 