### PR TITLE
chore(dep): bumped liquidJS@10.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
 			}
 		},
 		"node_modules/liquidjs": {
-			"version": "10.25.7",
-			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.7.tgz",
-			"integrity": "sha512-rPCjJLiD4eDhQjvv964AeXFC+HbeYBbZrd7Z82Q6hqv1lX7G+5w4SJcKLn9CAAAwHI4aS3dTdo083UB79K3pDA==",
+			"version": "10.27.0",
+			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+			"integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"express": "^4.22.0",
 		"har-validator": "^5.1.5",
 		"jstransformer-marked": "^1.4.0",
-		"liquidjs": "^10.25.2",
+		"liquidjs": "^10.27.0",
 		"method-override": "^3.0.0",
 		"morgan": "^1.10.1",
 		"pug": "^3.0.3",


### PR DESCRIPTION
This PR bumps liquidJS@10.27.0 and resolves the templating issue within CVE-2026-45618. 