### PR TITLE
fix(INS-2344): upgrade front-end libraries

### DIFF
--- a/src/static/bin/create.js
+++ b/src/static/bin/create.js
@@ -77,7 +77,7 @@ $(() => {
 		if (data) {
 			$('input[name="response"]').val(JSON.stringify(data));
 			$("pre code").text(JSON.stringify(data, null, 2));
-			hljs.highlightBlock($("pre code")[0]);
+			hljs.highlightElement($("pre code")[0]);
 		}
 	});
 
@@ -101,7 +101,7 @@ $(() => {
 				$('input[name="response"]').val(JSON.stringify(data));
 
 				$("pre code").text(JSON.stringify(data, null, 2));
-				hljs.highlightBlock($("pre code")[0]);
+				hljs.highlightElement($("pre code")[0]);
 			}
 		};
 
@@ -183,7 +183,7 @@ $(() => {
 		$('input[name="response"]').val(JSON.stringify(response));
 		$("pre code").text(JSON.stringify(response, null, 2));
 
-		hljs.highlightBlock($("pre code")[0]);
+		hljs.highlightElement($("pre code")[0]);
 	};
 
 	$(".toggle-comments").on("click", function (event) {

--- a/src/views/bin/log.pug
+++ b/src/views/bin/log.pug
@@ -83,6 +83,6 @@ block scripts
 
       // highlight the code
       $('pre code').each(function (i, block) {
-        hljs.highlightBlock(block);
+        hljs.highlightElement(block);
       });
     });

--- a/src/views/bin/view.pug
+++ b/src/views/bin/view.pug
@@ -29,6 +29,6 @@ block scripts
     $(function() {
       // highlight the code
       $('pre code').each(function (i, block) {
-        hljs.highlightBlock(block);
+        hljs.highlightElement(block);
       });
     });

--- a/src/views/default.pug
+++ b/src/views/default.pug
@@ -15,7 +15,7 @@ block content
         div.tab-content
           for key in ['json', 'yaml', 'xml']
             div(id= key).tab-pane.active.fade.in
-              button(data-clipboard-target='#{key}-code').btn.btn-default.btn-xs.btn-clipboard #[i.fa.fa-copy] #[span Copy to Clipboard]
+              button(data-clipboard-target=`${key}-code`).btn.btn-default.btn-xs.btn-clipboard #[i.fa.fa-copy] #[span Copy to Clipboard]
               pre: code(id=`${key}-code`)= data[key]
 
     br
@@ -25,21 +25,20 @@ block content
 block scripts
   script(type='text/javascript').
     $(function() {
-      // configure Zero Clipboard
-      ZeroClipboard.config({
-        swfPath: '//cdnjs.cloudflare.com/ajax/libs/zeroclipboard/2.2.0/ZeroClipboard.swf',
-        forceHandCursor: true,
-        trustedDomains: [window.location.host, "cdnjs.cloudflare.com"]
-      })
+      // copy to clipboard via the native Clipboard API (replaces the legacy Flash-based helper)
+      $('.btn-clipboard').on('click', function () {
+        var target = document.getElementById($(this).data('clipboard-target'));
 
-      // attach Zero Clipboard
-      new ZeroClipboard($('.btn-clipboard'))
+        if (target && navigator.clipboard) {
+          navigator.clipboard.writeText(target.textContent);
+        }
+      });
 
       // select first tab
       $('.nav-tabs a:first').tab('show');
 
       // highlight the code
       $('.tab-content pre code').each(function (i, block) {
-        hljs.highlightBlock(block);
+        hljs.highlightElement(block);
       });
     });

--- a/src/views/layout.pug
+++ b/src/views/layout.pug
@@ -7,16 +7,15 @@ html
 
     meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no')
 
-    link(rel='stylesheet', type='text/css', href='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.min.css', media='all')
+    link(rel='stylesheet', type='text/css', href='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css', media='all')
     link(rel='stylesheet', type='text/css', href='https://fonts.googleapis.com/css?family=Open+Sans:400,600|Source+Code+Pro:200,300,400,500,600,700,900', media='all')
     link(rel='stylesheet', type='text/css', href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.css', media='all')
-    link(rel='stylesheet', type='text/css', href='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css', media='all')
+    link(rel='stylesheet', type='text/css', href='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css', media='all')
     link(rel='stylesheet', type='text/css', href='/static/main.css', media='all')
 
-    script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js')
-    script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js')
-    script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js')
-    script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/zeroclipboard/2.2.0/ZeroClipboard.min.js')
+    script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js')
+    script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js')
+    script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js')
 
     block head
 

--- a/test/http/index.js
+++ b/test/http/index.js
@@ -9,6 +9,10 @@ app.set("view engine", "pug");
 app.set("views", path.join(__dirname, "..", "..", "src", "views"));
 
 app.use(cookieParser());
+app.use(
+	"/static",
+	express.static(path.join(__dirname, "..", "..", "src", "static")),
+);
 
 app.use("/", mockbin());
 
@@ -30,6 +34,47 @@ describe("HTTP", () => {
 
 		res.status.should.equal(200);
 		res.headers.get("content-type").should.equal("text/html; charset=utf-8");
+	});
+
+	describe("front-end pages render", () => {
+		it("GET / renders the home page", async () => {
+			const res = await fetch("http://localhost:3000/", {
+				headers: { Accept: "text/html" },
+			});
+
+			res.status.should.equal(200);
+			res.headers.get("content-type").should.equal("text/html; charset=utf-8");
+		});
+
+		it("GET /har renders the clipboard + highlight page with its dependencies", async () => {
+			const res = await fetch("http://localhost:3000/har", {
+				headers: { Accept: "text/html" },
+			});
+
+			res.status.should.equal(200);
+			res.headers.get("content-type").should.equal("text/html; charset=utf-8");
+
+			const html = await res.text();
+			html.should.containEql("btn-clipboard");
+			html.should.containEql("nav-tabs");
+
+			// the clipboard button's target must resolve to a real code element id,
+			// not a leaked Pug interpolation literal like `#{key}-code`
+			html.should.not.containEql("#{");
+			for (const key of ["json", "yaml", "xml"]) {
+				html.should.containEql(`data-clipboard-target="${key}-code"`);
+				html.should.containEql(`id="${key}-code"`);
+			}
+		});
+
+		it("serves the create.js static asset with its highlight wiring", async () => {
+			const res = await fetch("http://localhost:3000/static/bin/create.js");
+
+			res.status.should.equal(200);
+
+			const js = await res.text();
+			js.should.containEql("hljs.");
+		});
 	});
 
 	it("should send CORS headers", async () => {
@@ -255,5 +300,71 @@ describe("HTTP", () => {
 
 		res.status.should.equal(308);
 		res.headers.get("location").should.equal("http://mockbin.com/");
+	});
+
+	describe("front-end assets are patched", () => {
+		// numeric semver-ish compare: gte("3.7.2", "3.5.0") === true
+		const gte = (a, b) => {
+			const pa = a.split(".").map(Number);
+			const pb = b.split(".").map(Number);
+			for (let i = 0; i < 3; i++) {
+				if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) > (pb[i] || 0);
+			}
+			return true;
+		};
+		const versionOf = (html, re) => (html.match(re) || [])[1];
+
+		let home;
+		let har;
+
+		before(async () => {
+			home = await (
+				await fetch("http://localhost:3000/", {
+					headers: { Accept: "text/html" },
+				})
+			).text();
+			har = await (
+				await fetch("http://localhost:3000/har", {
+					headers: { Accept: "text/html" },
+				})
+			).text();
+		});
+
+		it("contains no vulnerable or Flash-based references", () => {
+			const blocklist = [
+				"jquery/2.1.3",
+				"twitter-bootstrap/3.3.4",
+				"highlight.js/8.4",
+				"zeroclipboard",
+				"ZeroClipboard",
+				".swf",
+				"highlightBlock",
+			];
+
+			for (const bad of blocklist) {
+				home.should.not.containEql(bad);
+				har.should.not.containEql(bad);
+			}
+		});
+
+		it("loads library versions at or above the patched floor", () => {
+			gte(
+				versionOf(home, /jquery\/(\d+\.\d+\.\d+)\//),
+				"3.5.0",
+			).should.be.true();
+			gte(
+				versionOf(home, /twitter-bootstrap\/(\d+\.\d+\.\d+)\//),
+				"3.4.1",
+			).should.be.true();
+			gte(
+				versionOf(home, /highlight\.js\/(\d+\.\d+\.\d+)\//),
+				"10.0.0",
+			).should.be.true();
+		});
+
+		it("uses the native Clipboard API for copy-to-clipboard", () => {
+			har.should.containEql("navigator.clipboard");
+			har.should.containEql("btn-clipboard");
+		});
 	});
 });


### PR DESCRIPTION
## What does this PR do
Upgrades the CDN-loaded front-end libraries to patched versions and removes the dead Flash-based clipboard dependency. 

## Changes
The following libraries have been updated or removed:  
- jQuery 2.1.3 -> 3.7.1 
- Bootstrap 3.3.4 -> 3.4.1 
- highlight.js 8.4 -> 11.9.0 (`hljs.highlightBlock` -> `highlightElement`)
- Removed ZeroClipboard 2.2.0 in favour of native `navigator.clipboard.writeText()`