### PR TITLE
Sec/stepsecurity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # Code owners are automatically requested for review on PRs.
-# Determined by commit frequency over the last 18 months (Jan 2025 – Jul 2026).
 
 * @yaoweiprc @kwburns-kong

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners are automatically requested for review on PRs.
+# Determined by commit frequency over the last 18 months (Jan 2025 – Jul 2026).
+
+* @yaoweiprc @kwburns-kong

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,10 @@ jobs:
     permissions:
       contents: write # publish sbom to GH releases/tag assets
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -59,6 +63,10 @@ jobs:
       image_tags: ${{ steps.meta.outputs.tags }}
       image_tag_version: ${{ steps.meta.outputs.version }}
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -135,6 +143,10 @@ jobs:
       github.repository_owner == 'Kong'
       && needs.build-images.result == 'success'
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Download OCI docker TAR artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -170,6 +182,10 @@ jobs:
       image_manifest_sha: ${{ steps.image_manifest_metadata.outputs.sha }}
       # notary_repository: ${{ env.NOTARY_REPOSITORY }}
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Download OCI docker TAR artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -26,5 +26,9 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Kong/public-shared-actions/security-actions/semgrep@a18abf762d6e2444bcbfd20de70451ea1e3bc1b1 # v4.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,10 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:


### PR DESCRIPTION
## What this PR does

- Add `step-security/harden-runner` (v2.19.4, SHA-pinned) in audit mode to all workflow jobs across `test.yaml`, `release.yaml`, and `sast.yml`. 
- Add `.github/CODEOWNERS` scoped to active maintainers based on commit frequency. 

## Why
- Closes out the remaining gaps in the supply-chain hardening pass. This will eventually be changed to block mode once enough samples are received. 
- Security policy requires CODEOWNERS be specified. @yaoweiprc, let me know if you want others added. 