### PR TITLE
chore: expand allowed chars in mock url paths

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,8 +44,10 @@ const utils = {
 				message: "The provided path exceeds the maximum character limit.",
 			};
 		}
-		// Limit what characters can be present in `path`.
-		if (!status && /[^a-zA-Z0-9\/\._-]/.test(path)) {
+		// Allow RFC 3986 path chars (unreserved + sub-delims + `:` + `@`) but not `%`.
+		// Express has already URL-decoded req.params by this point, so any `%` that
+		// reaches here is a stray literal, not the start of a `%XX` escape — reject it.
+		if (!status && /[^a-zA-Z0-9\-._~!$&'()*+,;=:@\/]/.test(path)) {
 			status = {
 				error: "Invalid Path Characters",
 				message: "The path contains illegal characters.",

--- a/test/utils.js
+++ b/test/utils.js
@@ -70,6 +70,98 @@ describe("Utils", () => {
 		});
 	});
 
+	describe("isValidCompoundId", () => {
+		const validId = `mock_${"a".repeat(32)}`;
+
+		it("should return null for a valid id and basic path", (done) => {
+			const result = utils.isValidCompoundId(validId, "/foo/bar_baz-qux~.txt");
+
+			should(result).be.exactly(null);
+
+			done();
+		});
+
+		it("should return null for a path with sub-delim characters", (done) => {
+			const result = utils.isValidCompoundId(
+				validId,
+				"/foo;bar=baz,qux!$&'()*+",
+			);
+
+			should(result).be.exactly(null);
+
+			done();
+		});
+
+		it("should return null for a path with `:` and `@`", (done) => {
+			const result = utils.isValidCompoundId(validId, "/foo:8080/@user");
+
+			should(result).be.exactly(null);
+
+			done();
+		});
+
+		it("should return null for a path containing `..`", (done) => {
+			const result = utils.isValidCompoundId(validId, "/foo/../bar");
+
+			should(result).be.exactly(null);
+
+			done();
+		});
+
+		it("should return an error for a path containing `%`", (done) => {
+			const result = utils.isValidCompoundId(validId, "/foo%2Fbar");
+
+			result.should.be.an.Object();
+			result.error.should.be.equal("Invalid Path Characters");
+
+			done();
+		});
+
+		it("should return an error for a path containing a space", (done) => {
+			const result = utils.isValidCompoundId(validId, "/foo bar");
+
+			result.should.be.an.Object();
+			result.error.should.be.equal("Invalid Path Characters");
+
+			done();
+		});
+
+		it("should return an error for a path containing `?`", (done) => {
+			const result = utils.isValidCompoundId(validId, "/foo?bar=1");
+
+			result.should.be.an.Object();
+			result.error.should.be.equal("Invalid Path Characters");
+
+			done();
+		});
+
+		it("should return an error for a malformed id", (done) => {
+			const result = utils.isValidCompoundId("not_a_valid_id", "/foo");
+
+			result.should.be.an.Object();
+			result.error.should.be.equal('Invalid Mock "id"');
+
+			done();
+		});
+
+		it("should return null for a path of exactly 1900 characters", (done) => {
+			const result = utils.isValidCompoundId(validId, `/${"a".repeat(1899)}`);
+
+			should(result).be.exactly(null);
+
+			done();
+		});
+
+		it("should return an error for a path of exactly 1901 characters", (done) => {
+			const result = utils.isValidCompoundId(validId, `/${"a".repeat(1900)}`);
+
+			result.should.be.an.Object();
+			result.error.should.be.equal('Invalid Mock "path" length');
+
+			done();
+		});
+	});
+
 	describe("createHar", () => {
 		const result = utils.createHar(fixture);
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -135,6 +135,48 @@ describe("Utils", () => {
 			done();
 		});
 
+		// Blocks markup-breaking chars, since the path is rendered raw into bin/view.pug.
+		['"', "<", ">"].forEach((char) => {
+			it(`should return an error for a path containing \`${char}\``, (done) => {
+				const result = utils.isValidCompoundId(validId, `/foo${char}bar`);
+
+				result.should.be.an.Object();
+				result.error.should.be.equal("Invalid Path Characters");
+
+				done();
+			});
+		});
+
+		// Blocks CRLF, since the path flows into the `Location` header and stored HAR logs.
+		["\r", "\n", "\r\n"].forEach((seq) => {
+			it(`should return an error for a path containing ${JSON.stringify(seq)}`, (done) => {
+				const result = utils.isValidCompoundId(validId, `/foo${seq}bar`);
+
+				result.should.be.an.Object();
+				result.error.should.be.equal("Invalid Path Characters");
+
+				done();
+			});
+		});
+
+		it("should return an error for a path containing a backslash", (done) => {
+			const result = utils.isValidCompoundId(validId, "/foo\\bar");
+
+			result.should.be.an.Object();
+			result.error.should.be.equal("Invalid Path Characters");
+
+			done();
+		});
+
+		it("should return an error for a path containing a null byte", (done) => {
+			const result = utils.isValidCompoundId(validId, "/foo\0bar");
+
+			result.should.be.an.Object();
+			result.error.should.be.equal("Invalid Path Characters");
+
+			done();
+		});
+
 		it("should return an error for a malformed id", (done) => {
 			const result = utils.isValidCompoundId("not_a_valid_id", "/foo");
 


### PR DESCRIPTION
https://github.com/Kong/insomnia-mockbin/pull/213/changes#diff-5dfe38baf287dcf756a17c2dd63483781b53bf4b669e10efdd01e74bcd8e780aR37 limited the allowed characters in mock URL paths. This PR expands allowed characters to those allowed by RFC 3986.

Before: paths were restricted to [a-zA-Z0-9/._-], rejecting many legal URL characters.

After: paths may contain RFC 3986 path characters - unreserved (A–Z a–z 0–9 - . _ ~), sub-delims (! $ & ' ( ) * + , ; =), and (: @ /).

% is still rejected. By the time this check runs, Express has already URL-decoded req.params, so any % reaching the validator is a stray literal rather than the start of a %XX escape sequence. The validated value is only ever used as an opaque Redis key (bin:/log:), so allowing . and / and .. carries no path-traversal risk.