### PR TITLE
chore(ci): add step-security/harden-runner in audit mode

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,11 @@ jobs:
     permissions:
       contents: write # publish sbom to GH releases/tag assets
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -59,6 +64,11 @@ jobs:
       image_tags: ${{ steps.meta.outputs.tags }}
       image_tag_version: ${{ steps.meta.outputs.version }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -135,6 +145,11 @@ jobs:
       github.repository_owner == 'Kong'
       && needs.build-images.result == 'success'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Download OCI docker TAR artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -170,6 +185,11 @@ jobs:
       image_manifest_sha: ${{ steps.image_manifest_metadata.outputs.sha }}
       # notary_repository: ${{ env.NOTARY_REPOSITORY }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Download OCI docker TAR artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -26,5 +26,9 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Kong/public-shared-actions/security-actions/semgrep@a18abf762d6e2444bcbfd20de70451ea1e3bc1b1 # v4.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,10 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:


### PR DESCRIPTION
**What this PR does:**
- Adds `step-security/harden-runner` as the first step in every job. Configured in `audit` mode (monitor only, does not block anything)
- Pinned to `step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920` (v2.20.0)