### PR TITLE
fix(sec): bump liquidjs, fast-uri, brace-expansion + chainguard base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/node:latest@sha256:7ce7491612c80eac34419a2d765ff73d4e1a5e791af0ef98c8d990b721340f46
+FROM cgr.dev/chainguard/node:latest@sha256:cf7ae5ead5aed79a61404d7b1bbb9b89ea461991b21cb8fcb07d4b6ad4d8b734
 
 ENV NODE_ENV production
 WORKDIR /usr/src/app

--- a/package-lock.json
+++ b/package-lock.json
@@ -564,9 +564,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2899,9 +2899,9 @@
 			}
 		},
 		"node_modules/yamljs/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"express": "^4.22.0",
 				"har-validator": "^5.1.5",
 				"jstransformer-marked": "^1.4.0",
-				"liquidjs": "^10.25.2",
+				"liquidjs": "^10.28.0",
 				"method-override": "^3.0.0",
 				"morgan": "^1.10.1",
 				"pug": "^3.0.3",
@@ -1699,9 +1699,9 @@
 			}
 		},
 		"node_modules/liquidjs": {
-			"version": "10.27.0",
-			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
-			"integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
+			"version": "10.28.0",
+			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.28.0.tgz",
+			"integrity": "sha512-b6tmBXYMQTuGPnM5vB0CuZMo5kvmKMtSB/gvUWP6RFn2pIB5s+bJkBfIyJnattkc5bgeAiflrZVptx3iaLLioQ==",
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1123,9 +1123,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"funding": [
 				{
 					"type": "github",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"express": "^4.22.0",
 		"har-validator": "^5.1.5",
 		"jstransformer-marked": "^1.4.0",
-		"liquidjs": "^10.27.0",
+		"liquidjs": "^10.28.0",
 		"method-override": "^3.0.0",
 		"morgan": "^1.10.1",
 		"pug": "^3.0.3",


### PR DESCRIPTION
## What this PR does 
* Bump liquidjs 10.27.0 → 10.28.0 (GHSA-g357-x5c3-c72p — pop filter bypasses memoryLimit)
* Bump fast-uri 3.1.2 → 3.1.5, transitive via ajv (GHSA-v2hh-gcrm-f6hx — host confusion via backslash authority delimiter)
* Bump brace-expansion to patched versions in both locations — top-level 2.0.3 → 2.1.4, and yamljs's nested 1.1.13 → 1.1.18 (GHSA-3jxr-9vmj-r5cp — DoS via exponential-time expansion)
* Bump chainguard node base image to current latest digest — resolves tar (→7.5.21) and Nghttp2 (→1.70.0) findings