### PR TITLE
chore: sec maintenance (dep bumps, workflow hardening, base image bump)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -31,4 +31,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: Kong/public-shared-actions/security-actions/semgrep@a18abf762d6e2444bcbfd20de70451ea1e3bc1b1 # v4.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,8 @@ jobs:
       with:
         egress-policy: audit
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 21

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/node:latest@sha256:cf7ae5ead5aed79a61404d7b1bbb9b89ea461991b21cb8fcb07d4b6ad4d8b734
+FROM cgr.dev/chainguard/node:latest@sha256:f2a8ed64ec02cef2e53c76d1255d0917e749570af251e32e99f54cda1076cc8d
 
 ENV NODE_ENV production
 WORKDIR /usr/src/app

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"cookie-parser": "^1.4.7",
 				"debug": "^4.3.4",
 				"dotenv": "^16.4.0",
-				"express": "^4.22.0",
+				"express": "^4.22.2",
 				"har-validator": "^5.1.5",
 				"jstransformer-marked": "^1.4.0",
 				"liquidjs": "^10.28.0",
@@ -525,9 +525,9 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.4",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+			"version": "1.20.6",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+			"integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "~3.1.2",
@@ -538,7 +538,7 @@
 				"http-errors": "~2.0.1",
 				"iconv-lite": "~0.4.24",
 				"on-finished": "~2.4.1",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
 				"unpipe": "~1.0.0"
@@ -1050,14 +1050,14 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
+				"body-parser": "~1.20.5",
 				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "~0.7.1",
@@ -1076,7 +1076,7 @@
 				"parseurl": "~1.3.3",
 				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
 				"send": "~0.19.0",
@@ -2272,12 +2272,13 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -2546,14 +2547,14 @@
 			"license": "MIT"
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
 				"side-channel-map": "^1.0.1",
 				"side-channel-weakmap": "^1.0.2"
 			},
@@ -2565,13 +2566,13 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@faker-js/faker": "^9.8.0",
 				"@idio/dicer": "1.1.0",
-				"ajv": "^8.18.0",
+				"ajv": "^8.20.0",
 				"ajv-formats": "^3.0.1",
 				"compression": "^1.8.1",
 				"content-type": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1123,9 +1123,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+			"integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
 			"funding": [
 				{
 					"type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -368,9 +368,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -1385,9 +1385,9 @@
 			}
 		},
 		"node_modules/har-validator/node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1921,19 +1921,23 @@
 			}
 		},
 		"node_modules/morgan": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-			"integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+			"integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
 			"license": "MIT",
 			"dependencies": {
 				"basic-auth": "~2.0.1",
 				"debug": "2.6.9",
 				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
+				"on-finished": "~2.4.1",
 				"on-headers": "~1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/morgan/node_modules/debug": {
@@ -1950,18 +1954,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"license": "MIT",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	"dependencies": {
 		"@faker-js/faker": "^9.8.0",
 		"@idio/dicer": "1.1.0",
-		"ajv": "^8.18.0",
+		"ajv": "^8.20.0",
 		"ajv-formats": "^3.0.1",
 		"compression": "^1.8.1",
 		"content-type": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"cookie-parser": "^1.4.7",
 		"debug": "^4.3.4",
 		"dotenv": "^16.4.0",
-		"express": "^4.22.0",
+		"express": "^4.22.2",
 		"har-validator": "^5.1.5",
 		"jstransformer-marked": "^1.4.0",
 		"liquidjs": "^10.28.0",


### PR DESCRIPTION
## Summary
- Bump express 4.22.0 -> 4.22.2, cascading body-parser 1.20.4 -> 1.20.6 (CVE-2026-12590) and qs 6.14.2 -> 6.15.3 (CVE-2026-8723)
- Bump morgan 1.10.1 -> 1.11.0 (CVE-2026-5078)
- Bump ajv 8.18.0 -> 8.20.0 (AIKIDO-2026-273849)
- Set `persist-credentials: false` on the actions/checkout steps in release.yaml (build-images job), sast.yml, and test.yaml
- Bumped cgr.dev/chainguard/node@sha256:cf7ae5e... (2026-08-03) to sha256:f2a8ed6... (2026-08-21)

## Test plan
- [x] `npm test` passes (one pre-existing, unrelated IPv6 test failure confirmed present on master too)
- [ ] CI (test.yaml) green on this PR -- used as the deploy verification for this change in place of a manual dev-environment regression run